### PR TITLE
Fix page load e2e test.

### DIFF
--- a/src/client/App/hydration.ts
+++ b/src/client/App/hydration.ts
@@ -52,4 +52,4 @@ export class PreloadedDataHydrator {
   }
 }
 
-export const context = new PreloadedDataHydrator(Math.random().toString());
+export const context = new PreloadedDataHydrator("context");

--- a/src/client/Pages/ShopBookingPage/useController.tsx
+++ b/src/client/Pages/ShopBookingPage/useController.tsx
@@ -34,10 +34,10 @@ export function useController(): Controller {
     },
     renderModal() {
       return (
-        <dialog open={this.isCTAOpen} data-testid="Party Size Modal">
-          <PartySizeList partySize={this.partySize} />
+        <dialog open={state.isCTAOpen} data-testid="Party Size Modal">
+          <PartySizeList partySize={state.partySize} />
 
-          <button onClick={this.closeCTA}>close</button>
+          <button onClick={api.closeCTA}>close</button>
         </dialog>
       );
     },


### PR DESCRIPTION
Root cause:
1. An error message shows "There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering." => If the content rendered by the server doesn't exactly match what React expects on the client during the initial render, React will throw a hydration error.
The difference between passing `Math.random().toString()` and "context" to the `PreloadedDataHydrator `constructor is in the uniqueness of the id.
In our case, we are passing the global store to the `App` so we would like to pass a fixed `id` to make sure the id consistency across server and client.

2. In `useController`, In functional components, this doesn't refer to an instance of the component like it does in class components. It refers to the global object or be undefined in strict mode, which can lead to errors. Use `state.isCTAOpen`, `state.partySize` and `api.closeCTA` in the `renderModal` method, avoiding `this`.