### PR TITLE
Refactor OASClientFromSpec to accept undefined producer

### DIFF
--- a/openapi/OasClientFromSpec.ts
+++ b/openapi/OasClientFromSpec.ts
@@ -101,16 +101,24 @@ export class OASClientFromSpec {
             ])
           ),
         ]),
-        b.variableDeclaration("const", [
-          b.variableDeclarator(
-            b.identifier("result"),
-            b.callExpression(b.identifier("produce"), [
-              b.identifier("faked"),
-              b.identifier("producer"),
-            ])
-          ),
-        ]),
-        b.returnStatement(b.identifier("result")),
+        b.ifStatement(
+          b.binaryExpression("!==", b.identifier("producer"), b.identifier("undefined")),
+          b.blockStatement([
+            b.variableDeclaration("const", [
+              b.variableDeclarator(
+                b.identifier("result"),
+                b.callExpression(b.identifier("produce"), [
+                  b.identifier("faked"),
+                  b.identifier("producer"),
+                ])
+              ),
+            ]),
+            b.returnStatement(b.identifier("result")),
+          ]),
+          b.blockStatement([
+            b.returnStatement(b.identifier("faked")),
+          ])
+        ),
       ])
     );
   }

--- a/openapi/spec.json
+++ b/openapi/spec.json
@@ -68,6 +68,59 @@
           }
         }
       }
+    },
+    "/shops/{shop}": {
+      "get": {
+        "summary": "Get a single shop",
+        "responses": {
+          "200": {
+            "description": "All went well",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "slug",
+                    "minNumPeople",
+                    "maxNumPeople",
+                    "showBaby",
+                    "showChild",
+                    "showSenior"
+                  ],
+                  "$ref": "#/components/schemas/Shop"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/shops/{shop}/menu": {
+      "get": {
+        "summary": "Get a single shop's menu",
+        "responses": {
+          "200": {
+            "description": "All went well",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "id",
+                      "title",
+                      "description",
+                      "isGroupOrder",
+                      "minOrderQty",
+                      "maxOrderQty"
+                    ],
+                    "$ref": "#/components/schemas/MenuItem"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {


### PR DESCRIPTION
Key change:
1. Refactor OASClientFromSpec to accept undefined producer.

Based on test case:
1. Add two API endpoints: `/shops/{shop}` and `/shops/{shop}/menu`.