### PR TITLE
Add teardown API call to avoid using cached mock data

### DIFF
--- a/src/server/server.tsx
+++ b/src/server/server.tsx
@@ -56,6 +56,7 @@ class Server {
       const { data: menu } = await this.instance.get<MenuItem[]>(
         `/shops/${req.params.shop}/menu`
       );
+      await this.instance.get(`teardown`);
       shop.slug = req.params.shop;
       const store = {
         shop,


### PR DESCRIPTION
I have successfully resolved an issue by adding a `teardown` endpoint to bookingHandler. Initially, I encountered a problem where the store data remained unchanged after setting mock data. This led me to investigate the potential causes related to server-side rendering and the OpenAPI server configuration.

After few nights, I discovered that simply restarting the OpenAPI server caused the mock data to revert to its default state. This behavior pointed to an issue where the `interceptors` within the OpenAPI server's configuration was persistently storing mock data without being cleared. To address this, I implemented a teardown` endpoint that is triggered after mock data retrieval. This ensures the state is reset, preventing data persistence issues.