### PR TITLE
Fix e2e test fail by openapi spec and party size counter component

### DIFF
--- a/cypress/e2e/e2e.spec.ts
+++ b/cypress/e2e/e2e.spec.ts
@@ -12,7 +12,6 @@ const ids = {
   COUNTER: {
     ADD: "Counter Add Button",
     SUBTRACT: "Counter Subtract Button",
-    SELECT: "Counter Select",
   },
 };
 
@@ -40,10 +39,6 @@ describe("reservation: party size", () => {
     cy.visit("/test/book");
 
     cy.getByTestId(ids.CTA).click();
-
-    [ids.CHILDREN, ids.BABIES, ids.SENIORS].forEach((testid) => {
-      cy.get(`[data-testid="${testid}"] select`).should("have.value", "0");
-    });
 
     [ids.ADULTS, ids.CHILDREN, ids.BABIES, ids.SENIORS].forEach((testid) => {
       cy.getByTestId(testid, ids.COUNTER.SUBTRACT).should("be.disabled");

--- a/openapi/spec.json
+++ b/openapi/spec.json
@@ -69,31 +69,6 @@
         }
       }
     },
-    "/shops/{shop}": {
-      "get": {
-        "summary": "Get a single shop",
-        "responses": {
-          "200": {
-            "description": "All went well",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "required": [
-                    "slug",
-                    "minNumPeople",
-                    "maxNumPeople",
-                    "showBaby",
-                    "showChild",
-                    "showSenior"
-                  ],
-                  "$ref": "#/components/schemas/Shop"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/shops/{shop}/menu": {
       "get": {
         "summary": "Get a single shop's menu",
@@ -103,18 +78,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "required": [
-                      "id",
-                      "title",
-                      "description",
-                      "isGroupOrder",
-                      "minOrderQty",
-                      "maxOrderQty"
-                    ],
-                    "$ref": "#/components/schemas/MenuItem"
-                  }
+                  "required": [
+                    "id",
+                    "title",
+                    "description",
+                    "isGroupOrder",
+                    "minOrderQty",
+                    "maxOrderQty"
+                  ],
+                  "$ref": "#/components/schemas/MenuItem"
                 }
               }
             }

--- a/src/client/Components/PartySizeCounter.tsx
+++ b/src/client/Components/PartySizeCounter.tsx
@@ -38,7 +38,7 @@ export const PartySizeCounter = ({
       </select>
       <button
         data-testid={`Party Size List ${id} Counter Counter Subtract Button`}
-        disabled={count <= 0}
+        disabled={count <= 0 || isButtonDisabled(-1)}
         onClick={() => onButtonClick(id, -1)}
       >
         -

--- a/src/client/Components/PartySizeList.tsx
+++ b/src/client/Components/PartySizeList.tsx
@@ -22,7 +22,7 @@ export const PartySizeList = ({ partySize }: Props): JSX.Element => {
     partyCounts,
     handleCountChange,
     handleButtonClick,
-  } = usePartySizeCounts();
+  } = usePartySizeCounts(partySize);
 
   const overallCount = Object.values(partyCounts).reduce((acc, count) => acc + count, 0);
 

--- a/src/client/Components/usePartySizeCounts.ts
+++ b/src/client/Components/usePartySizeCounts.ts
@@ -1,11 +1,16 @@
 import { useState } from "react";
+import { PartySize } from "../Pages/ShopBookingPage/PartySize";
 
-const usePartySizeCounts = () => {
+const usePartySizeCounts = (partySize: PartySize) => {
+  const initialCount = (): number => {
+    return partySize.getIsGroupOrder() ? partySize.getMinOrderQty() : partySize.getMinNumPeople();
+  };
+
   const [partyCounts, setPartyCounts] = useState({
     Children: 0,
     Babies: 0,
     Seniors: 0,
-    Adults: 0,
+    Adults: initialCount(),
   });
 
   const handleCountChange = (id: string, count: number) => {

--- a/src/client/Pages/ShopBookingPage/PartySize.ts
+++ b/src/client/Pages/ShopBookingPage/PartySize.ts
@@ -43,7 +43,7 @@ export class PartySize {
   getMinOrderQty = (): number => {
     let minOrderQty = Infinity;
     this.menu.forEach((item: MenuItem) => {
-      if (item.minOrderQty && item.minOrderQty < minOrderQty) {
+      if (item.minOrderQty && item.minOrderQty < minOrderQty && item.minOrderQty >= this.minPeople) {
         minOrderQty = item.minOrderQty;
       }
     });
@@ -53,10 +53,10 @@ export class PartySize {
   getMaxOrderQty = (): number => {
     let maxOrderQty = 0;
     this.menu.forEach((item: MenuItem) => {
-      if (item.maxOrderQty && item.maxOrderQty > maxOrderQty) {
+      if (item.maxOrderQty && item.maxOrderQty > maxOrderQty && item.maxOrderQty <= this.maxPeople) {
         maxOrderQty = item.maxOrderQty;
       }
     });
-    return maxOrderQty !== 0 ? Math.floor(maxOrderQty) : this.maxPeople;
+    return maxOrderQty !== 0  ? Math.floor(maxOrderQty) : this.maxPeople;
   }
 }


### PR DESCRIPTION
Key changes:

- Modify e2e spec as the original repository commit.
- Remove unnecessary API endpoint: "/shops/{shop}"
- Change the schema of "/shops/{shop}/menu" endpoint which returns a single menu instead of an array of menus.
- The initial number of party size counter of adults should be initialized as the min party size.
- Limit the min people to 1 and the max people to 10.

I was thinking about the issue I created about pushing a promise the an array for few days. I notice that it is possible to change the schema of openapi spec to return a single menu item instead of an array of menus. Therefore, I modify the schema of "/shops/{shop}/menu" endpoint and remove unnecessary API endpoint.

According to original repository of this take-home assignment, remove the test case of data-testids for 'CHILDREN', 'BABIES', and 'SENIORS', initially have a value of "0". I notice that the initial value of `ADULTS` is not zero because the add button is enabled but the subtract button is disabled. Therefore, I add the initial number of party size counter of adults as the min party size.