### PR TITLE
Use alternative approach to secure Cypress e2e reliability

### DIFF
--- a/cypress/support/commands/api.ts
+++ b/cypress/support/commands/api.ts
@@ -11,6 +11,7 @@ declare global {
     interface Chainable {
       mock: (match: string, producer: any, key?: string) => Chainable;
       unmock: (key: string) => Chainable;
+      teardown: () => Chainable;
     }
   }
 }
@@ -31,5 +32,12 @@ Cypress.Commands.add("mock", (match, producer, key) =>
 Cypress.Commands.add("unmock", (key) =>
   cy.then(async () => {
     await axios.post("/unmock", { key });
+  })
+);
+
+
+Cypress.Commands.add("teardown", () =>
+  cy.then(async () => {
+    await axios.get("/teardown");
   })
 );

--- a/cypress/support/commands/utils.ts
+++ b/cypress/support/commands/utils.ts
@@ -9,7 +9,9 @@ declare global {
 }
 
 Cypress.Commands.add("getByTestId", (...testids) => {
-  const selector = testids.map((testid) => testid).join(" ");
+  const selector = testids
+    .map((testid) => `[data-testid="${testid}"]`)
+    .join(" ");
 
-  return cy.get(`[data-testid="${selector}"]`);
+  return cy.get(selector);
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,2 +1,7 @@
+import { afterEach, cy } from "local-cypress";
 import "./commands/api";
 import "./commands/utils";
+
+afterEach(() => {
+  cy.teardown();
+});

--- a/src/client/Components/PartySizeCounter.tsx
+++ b/src/client/Components/PartySizeCounter.tsx
@@ -23,10 +23,10 @@ export const PartySizeCounter = ({
   };
 
   return (
-    <div>
+    <div data-testid={`Party Size List ${id} Counter`}>
       <span>{id}</span>
       <select
-        data-testid={`Party Size List ${id} Counter`}
+        data-testid={`Counter Select`}
         value={count}
         onChange={handleCountChange}
       >
@@ -37,14 +37,14 @@ export const PartySizeCounter = ({
         ))}
       </select>
       <button
-        data-testid={`Party Size List ${id} Counter Counter Subtract Button`}
+        data-testid={`Counter Subtract Button`}
         disabled={count <= 0 || isButtonDisabled(-1)}
         onClick={() => onButtonClick(id, -1)}
       >
         -
       </button>
       <button
-        data-testid={`Party Size List ${id} Counter Counter Add Button`}
+        data-testid={`Counter Add Button`}
         disabled={isButtonDisabled(1)}
         onClick={() => onButtonClick(id, 1)}
       >

--- a/src/server/server.tsx
+++ b/src/server/server.tsx
@@ -56,7 +56,7 @@ class Server {
       const { data: menu } = await this.instance.get<MenuItem[]>(
         `/shops/${req.params.shop}/menu`
       );
-      await this.instance.get(`teardown`);
+
       shop.slug = req.params.shop;
       const store = {
         shop,


### PR DESCRIPTION
Key changes:

1. Leverage Cypress's support for global hooks to teardown `interceptors` instead of applying teardown execution in server side. The main idea to clear out `interceptors` is for Cypress e2e test. Therefore, we should keep the logic in Cypress separately without modifying `e2e.spec.ts`
2. Restore cypress command: `getByTestId` for descendant combinator. The original idea is combining descendant selectors in a single array of `data-testid`. Therefore, I restore `getByTestId` and modify `PartySizeCounter` component.
