### PR TITLE
Refactor OASClientFromSpec to accept optional producer

### DIFF
--- a/openapi/OasClientFromSpec.ts
+++ b/openapi/OasClientFromSpec.ts
@@ -91,7 +91,12 @@ export class OASClientFromSpec {
   buildClientMethodDefinition(schema: PropertyKind[]): FunctionExpressionKind {
     return b.functionExpression(
       null,
-      [b.identifier("producer")],
+      [
+        b.assignmentPattern(
+          b.identifier("producer"),
+          b.identifier("undefined")
+        ),
+      ],
       b.blockStatement([
         b.variableDeclaration("const", [
           b.variableDeclarator(
@@ -102,7 +107,11 @@ export class OASClientFromSpec {
           ),
         ]),
         b.ifStatement(
-          b.binaryExpression("!==", b.identifier("producer"), b.identifier("undefined")),
+          b.binaryExpression(
+            "===",
+            b.unaryExpression("typeof", b.identifier("producer")),
+            b.literal("function")
+          ),
           b.blockStatement([
             b.variableDeclaration("const", [
               b.variableDeclarator(
@@ -115,9 +124,7 @@ export class OASClientFromSpec {
             ]),
             b.returnStatement(b.identifier("result")),
           ]),
-          b.blockStatement([
-            b.returnStatement(b.identifier("faked")),
-          ])
+          b.blockStatement([b.returnStatement(b.identifier("faked"))])
         ),
       ])
     );


### PR DESCRIPTION
Key changes"
1. The default value of `producer` is set to `b.identifier("undefined")`, making the producer parameter effectively optional.
2. The `ifStatement` checks if `producer` is explicitly a function. This is a more precise check than simply checking against `undefined` because it ensures that `producer` is not only present but also callable.

`client.generated.ts`
```ts
"get /shops/:shop/menu 200": function (producer = undefined) {
    const faked = jsf.generate({
      // ...existed code
    });
    if (typeof producer === "function") {
      const result = produce(faked, producer);
      return result;
    } else {
      return faked;
    }
  }
```